### PR TITLE
Add colored output for build and watch scripts

### DIFF
--- a/packages/daft/config/package.json
+++ b/packages/daft/config/package.json
@@ -21,7 +21,7 @@
     "css:watch": "npm run css:build -- --watch",
     "lint": "concurrently 'npm:js:lint' 'npm:css:lint'",
     "format": "concurrently 'npm:js:format' 'npm:css:format'",
-    "build": "concurrently 'npm:typecheck:check' 'npm:js:build' 'npm:css:build' 'npm:images:build' 'npm:fonts:build' -c 'bgBlue.bold,bgYellow.bold,bgMagenta.bold,bgYellow.bold,bgCyan.bold'",
-    "watch": "concurrently 'npm:typecheck:watch' 'npm:js:watch' 'npm:css:watch' 'npm:images:watch' 'npm:fonts:watch' -c 'blue,yellow,magenta,yellow,cyan'"
+    "build": "concurrently 'npm:typecheck:check' 'npm:js:build' 'npm:css:build' 'npm:images:build' 'npm:fonts:build' -c 'bgBlue.bold,bgYellow.bold,bgMagenta.bold,bgGreen.bold,bgCyan.bold'",
+    "watch": "concurrently 'npm:typecheck:watch' 'npm:js:watch' 'npm:css:watch' 'npm:images:watch' 'npm:fonts:watch' -c 'blue,yellow,magenta,green,cyan'"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
* Adds colored output to watch and build scripts to make it easier to see what is running.

#### Screenshots (if appropriate)
Build script will be in bold:
<img width="1440" alt="Screenshot 2021-10-08 at 11 37 02" src="https://user-images.githubusercontent.com/68547893/136534199-85d68a5b-d1a8-43d8-9bfd-7ae41a2ed256.png">


Watch script will have colored text, no bold:
<img width="1272" alt="Screenshot 2021-10-08 at 11 37 19" src="https://user-images.githubusercontent.com/68547893/136534218-fd301b30-13c3-4c33-8b69-077e0810637d.png">
