### PR TITLE
Use new version of stylelint-recommended-scss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/@reloaddk/stylelint-recommended-scss": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@reloaddk/stylelint-recommended-scss/-/stylelint-recommended-scss-0.3.0.tgz",
-      "integrity": "sha512-m/0uFjsLrP1Vn9xqBSwilFKhrqM7zy9o35WdAF0+/+Gmk2BlBhcTZnMKp0urc34QF73XplJUYIomkJw1pg4n9g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@reloaddk/stylelint-recommended-scss/-/stylelint-recommended-scss-0.4.0.tgz",
+      "integrity": "sha512-bzhvBiPjak69O+5PtN4+sIEB3XuCM+fqBEVrRZVo+rrmeh2myJzWCRj5tok83n2Ce1L9F362HgurVAEBAK5Rgw==",
       "peer": true,
       "dependencies": {
         "stylelint-config-prettier": "^8.0.2",
@@ -7935,7 +7935,7 @@
         "@babel/core": "^7.15.5",
         "@babel/preset-env": "^7.15.6",
         "@reloaddk/stylelint-recommended": "^0.2.0",
-        "@reloaddk/stylelint-recommended-scss": "^0.3.0",
+        "@reloaddk/stylelint-recommended-scss": "^0.4.0",
         "@swc/cli": "^0.1.46",
         "@swc/core": "^1.2.66",
         "browserslist": "^4.16.6",
@@ -9185,9 +9185,9 @@
       }
     },
     "@reloaddk/stylelint-recommended-scss": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@reloaddk/stylelint-recommended-scss/-/stylelint-recommended-scss-0.3.0.tgz",
-      "integrity": "sha512-m/0uFjsLrP1Vn9xqBSwilFKhrqM7zy9o35WdAF0+/+Gmk2BlBhcTZnMKp0urc34QF73XplJUYIomkJw1pg4n9g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@reloaddk/stylelint-recommended-scss/-/stylelint-recommended-scss-0.4.0.tgz",
+      "integrity": "sha512-bzhvBiPjak69O+5PtN4+sIEB3XuCM+fqBEVrRZVo+rrmeh2myJzWCRj5tok83n2Ce1L9F362HgurVAEBAK5Rgw==",
       "peer": true,
       "requires": {
         "stylelint-config-prettier": "^8.0.2",

--- a/packages/daft/package.json
+++ b/packages/daft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reloaddk/daft",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "author": {
@@ -32,7 +32,7 @@
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
     "@reloaddk/stylelint-recommended": "^0.2.0",
-    "@reloaddk/stylelint-recommended-scss": "^0.3.0",
+    "@reloaddk/stylelint-recommended-scss": "^0.4.0",
     "@swc/cli": "^0.1.46",
     "@swc/core": "^1.2.66",
     "browserslist": "^4.16.6",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -31,8 +31,8 @@
     "start": "concurrently 'npm:watch' 'npm:serve' --raw"
   },
   "devDependencies": {
-    "@reloaddk/daft": "^1.1.0",
-    "@types/jquery": "^3.5.11",
+    "@reloaddk/daft": "^1.2.0",
+    "@types/jquery": "^3.5.6",
     "@types/lodash": "^4.14.171",
     "serve": "^13.0.2"
   }


### PR DESCRIPTION
We've raised the version for stylelint-recommended-scss in https://github.com/reload/stylelint/pull/2. Make daft use this new version
