### PR TITLE
Add reload/developers as dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: monthly
       timezone: Europe/Copenhagen
     reviewers:
-      - mikkelblyme
+      - "reload/developers"


### PR DESCRIPTION
#### What does this PR do?
Add reload/developers as dependabot reviewers. This should send the dependabot alert to zulip